### PR TITLE
Unshift

### DIFF
--- a/src/storefront/color_swap.clj
+++ b/src/storefront/color_swap.clj
@@ -52,4 +52,4 @@
               (concat (rest (:effects state)) [(first (:effects state))]))})
 
 (def drawing
-  (Drawing. "Color Swap" setup update-state draw-state nil nil))
+  (Drawing. "Color Swap" setup update-state draw-state nil nil nil))

--- a/src/storefront/shifting_grid.clj
+++ b/src/storefront/shifting_grid.clj
@@ -56,7 +56,7 @@
         start   (rand-int max)
         size    chunk-size
         columns (n-indices-wrapped size start max)
-        rotated (if column? matrix (m/transpose matrix))
+        rotated (if column? (vec matrix) (m/transpose matrix))
         rotate-nth (rotate-nth-generator max-rotation)
         [shifted ops] (reduce rotate-nth [rotated []] columns)
         ops (map #(concat [column?] %) ops)]
@@ -71,7 +71,7 @@
             [blocks new-ops] (random-rotation blocks max-rotation chunk-size)
             ops (conj ops new-ops)]
       [blocks ops]))
-    [blocks []] (range 50)))
+    [blocks []] (range 100)))
 
 
 (defn undo-op [blocks op]
@@ -86,7 +86,6 @@
 (defn undo-first [blocks ops]
   (let [opset (peek ops)
         ops (pop ops)
-        ; _meh (println opset)
         blocks (reduce undo-op blocks opset)]
   [blocks ops]))
 
@@ -97,13 +96,15 @@
         _resized (q/resize image (q/width) (q/height))
         x-blocks (:x-blocks options)
         y-blocks (:y-blocks options)
+        max-rotation (:max-rotation options)
+        chunk-size (:chunk-size options)
         block-w (/ (q/width) x-blocks)
         block-h (/ (q/height) y-blocks)
         xs     (map #(* % block-w) (range x-blocks))
         ys     (map #(* % block-h) (range y-blocks))
-        blocks (doall (map (fn [x] (map (fn [y] (q/get-pixel image x y block-w block-h)) ys)) xs))
+        blocks (map (fn [x] (map (fn [y] (q/get-pixel image x y block-w block-h)) ys)) xs)
         [blocks ops] (if (:backwards options)
-                         (pre-mix blocks (:max-rotation options) (:chunk-size options))
+                         (pre-mix blocks max-rotation chunk-size)
                          [blocks nil])]
         { :blocks blocks
           :options options

--- a/src/storefront/shifting_grid.clj
+++ b/src/storefront/shifting_grid.clj
@@ -23,7 +23,7 @@
       :default 3
       :parse-fn #(Integer/parseInt %)
       :validate [#(< 1 % 10) "Must be a number between 1 and 10"]]
-    [nil "--backwards", "Pre-mix and run it backwards"]
+    [nil "--mix", "Endlessly mix the drawing"]
   ])
 
 (defn draw-block [block x-index y-index w h]
@@ -103,9 +103,9 @@
         xs     (map #(* % block-w) (range x-blocks))
         ys     (map #(* % block-h) (range y-blocks))
         blocks (map (fn [x] (map (fn [y] (q/get-pixel image x y block-w block-h)) ys)) xs)
-        [blocks ops] (if (:backwards options)
-                         (pre-mix blocks max-rotation chunk-size)
-                         [blocks nil])]
+        [blocks ops] (if (:mix options)
+                         [blocks nil]
+                         (pre-mix blocks max-rotation chunk-size))]
         { :blocks blocks
           :options options
           :block-w block-w
@@ -117,9 +117,9 @@
         max-rotation (:max-rotation options)
         chunk-size (:chunk-size options)
         ops (:ops state)
-        [blocks ops] (if (:backwards options)
-                         (undo-first (:blocks state) ops)
-                         (random-rotation (:blocks state) max-rotation chunk-size))]
+        [blocks ops] (if (:mix options)
+                         (random-rotation (:blocks state) max-rotation chunk-size)
+                         (undo-first (:blocks state) ops))]
     (-> state
       (assoc :blocks blocks)
       (assoc :ops ops))))

--- a/src/storefront/shifting_grid.clj
+++ b/src/storefront/shifting_grid.clj
@@ -5,37 +5,6 @@
             [clojure.core.matrix :as m])
   (:import  [storefront.drawing Drawing]))
 
-(defn draw-block [block x-index y-index w h]
-  (let [x                 (* w x-index)
-        y                 (* h y-index)]
-    (q/rect x y w h)
-    (q/image block x y w h)))
-
-(defn rand-speed [min-max]
-  ((rand-nth [- +]) 0 (+ (rand-int min-max) 1)))
-
-(defn rotate-nth-generator [max-rotation]
-  (fn [matrix n]
-    (let [shift (rand-speed max-rotation)]
-      (update-in matrix [n] #(m/rotate % 0 shift)))))
-
-; Returns n indices, from start, and wrapping after max
-(defn n-indices-wrapped [n start y]
-  (map #(mod % y) (map #(+ start %) (range n))))
-
-(defn random-rotation [matrix max-rotation chunk-size]
-  (let [column? (rand-nth '(true false))
-        x-blocks (count matrix)
-        y-blocks (count (first matrix))
-        max     (if column? (- x-blocks 1) (- y-blocks 1))
-        start   (rand-int max)
-        size    chunk-size
-        columns (n-indices-wrapped size start max)
-        rotated (if column? matrix (m/transpose matrix))
-        rotate-nth (rotate-nth-generator max-rotation)
-        shifted (reduce rotate-nth rotated columns)]
-    (if column? shifted (m/transpose shifted))))
-
 (def cli-options
   [
     ["-x" "--x-blocks INT" "Number of blocks in the horizontal"
@@ -54,7 +23,72 @@
       :default 3
       :parse-fn #(Integer/parseInt %)
       :validate [#(< 1 % 10) "Must be a number between 1 and 10"]]
+    [nil "--backwards", "Pre-mix and run it backwards"]
   ])
+
+(defn draw-block [block x-index y-index w h]
+  (let [x                 (* w x-index)
+        y                 (* h y-index)]
+    (q/rect x y w h)
+    (q/image block x y w h)))
+
+(defn rand-speed [min-max]
+  ((rand-nth [- +]) 0 (+ (rand-int min-max) 1)))
+
+(defn rotate-nth-generator [max-rotation]
+  (fn [pair n]
+    (let [shift        (rand-speed max-rotation)
+          [matrix ops] pair
+          rotated      (assoc matrix n (m/rotate (nth matrix n) 0 shift))
+          op  [n shift]
+          ops (conj ops op)]
+      [rotated ops])))
+
+; Returns n indices, from start, and wrapping after max
+(defn n-indices-wrapped [n start y]
+  (map #(mod % y) (map #(+ start %) (range n))))
+
+(defn random-rotation [matrix max-rotation chunk-size]
+  (let [column? (rand-nth '(true false))
+        x-blocks (count matrix)
+        y-blocks (count (first matrix))
+        max     (if column? (- x-blocks 1) (- y-blocks 1))
+        start   (rand-int max)
+        size    chunk-size
+        columns (n-indices-wrapped size start max)
+        rotated (if column? matrix (m/transpose matrix))
+        rotate-nth (rotate-nth-generator max-rotation)
+        [shifted ops] (reduce rotate-nth [rotated []] columns)
+        ops (map #(concat [column?] %) ops)]
+    (if column?
+      [shifted ops]
+      [(m/transpose shifted) ops])))
+
+(defn pre-mix [blocks max-rotation chunk-size]
+  (reduce
+    (fn [pair _n]
+      (let [[blocks ops] pair
+            [blocks new-ops] (random-rotation blocks max-rotation chunk-size)
+            ops (conj ops new-ops)]
+      [blocks ops]))
+    [blocks []] (range 50)))
+
+
+(defn undo-op [blocks op]
+  (let [[column? idx shift] op
+        shift (- 0 shift)
+        blocks (if column? blocks (m/transpose blocks))
+        blocks (assoc blocks idx (m/rotate (nth blocks idx) 0 shift))
+        blocks (if column? blocks (m/transpose blocks))]
+    blocks))
+
+
+(defn undo-first [blocks ops]
+  (let [opset (peek ops)
+        ops (pop ops)
+        ; _meh (println opset)
+        blocks (reduce undo-op blocks opset)]
+  [blocks ops]))
 
 (defn setup [options]
   (q/frame-rate 5)
@@ -67,17 +101,27 @@
         block-h (/ (q/height) y-blocks)
         xs     (map #(* % block-w) (range x-blocks))
         ys     (map #(* % block-h) (range y-blocks))
-        blocks (map (fn [x] (map (fn [y] (q/get-pixel image x y block-w block-h)) ys)) xs)]
+        blocks (doall (map (fn [x] (map (fn [y] (q/get-pixel image x y block-w block-h)) ys)) xs))
+        [blocks ops] (if (:backwards options)
+                         (pre-mix blocks (:max-rotation options) (:chunk-size options))
+                         [blocks nil])]
         { :blocks blocks
           :options options
           :block-w block-w
-          :block-h block-h }))
+          :block-h block-h
+          :ops ops }))
 
 (defn update-state [state]
   (let [options (:options state)
         max-rotation (:max-rotation options)
-        chunk-size (:chunk-size options)]
-    (update-in state [:blocks] #(random-rotation % max-rotation chunk-size))))
+        chunk-size (:chunk-size options)
+        ops (:ops state)
+        [blocks ops] (if (:backwards options)
+                         (undo-first (:blocks state) ops)
+                         (random-rotation (:blocks state) max-rotation chunk-size))]
+    (-> state
+      (assoc :blocks blocks)
+      (assoc :ops ops))))
 
 (defn draw-state [state]
   (dorun

--- a/src/storefront/shifting_grid.clj
+++ b/src/storefront/shifting_grid.clj
@@ -133,5 +133,9 @@
         column)))
     (:blocks state))))
 
+(defn exit? [state]
+  (let [ops (:ops state)]
+  (= (count ops) 0)))
+
 (def drawing
-  (Drawing. "Shifting Grid" setup update-state draw-state cli-options nil nil))
+  (Drawing. "Shifting Grid" setup update-state draw-state cli-options exit? nil))

--- a/src/storefront/shifting_grid.clj
+++ b/src/storefront/shifting_grid.clj
@@ -82,12 +82,14 @@
         blocks (if column? blocks (m/transpose blocks))]
     blocks))
 
-
-(defn undo-first [blocks ops]
+(defn pop-block [blocks ops]
   (let [opset (peek ops)
         ops (pop ops)
         blocks (reduce undo-op blocks opset)]
-  [blocks ops]))
+    [blocks ops]))
+
+(defn undo-first [blocks ops]
+  (if (empty? ops) [blocks ops] (pop-block blocks ops)))
 
 (defn setup [options]
   (q/frame-rate 5)

--- a/src/storefront/throw.clj
+++ b/src/storefront/throw.clj
@@ -33,4 +33,4 @@
   (q/fill 255)
   (q/ellipse (:loc state) (/ (q/height) 2) csize csize))
 
-(def drawing (Drawing. "throw" setup update-state draw-state cli-options nil))
+(def drawing (Drawing. "throw" setup update-state draw-state cli-options nil nil))


### PR DESCRIPTION
This changes shifting-grid to the reverse of what it was. Now, before the animation starts, it will "pre-mix" the image, then the animation will unmix the image, so at the end, it will be the real image. I've made the default, and if you want to run the old animation, you can do `lein run shifting-grid --mix`

I also fixed some existing drawings that became broken with the last PR merge, and I smashed a very persistent bug in shifting grid.