### PR TITLE
Add LED animation to pixelate drawing

### DIFF
--- a/src/storefront/pixelate.clj
+++ b/src/storefront/pixelate.clj
@@ -68,8 +68,8 @@
         window-height (int (* height led/row-count))]
     { :x-start window-x
       :y-start window-y
-      :x-end (+ window-x window-width)
-      :y-end (+ window-y window-height) }))
+      :x-end (+ 1 (+ window-x window-width))
+      :y-end (+ 1 (+ window-y window-height)) }))
 
 (defn decompose-color [color]
   [(q/red color) (q/green color) (q/blue color)])

--- a/src/storefront/pixelate.clj
+++ b/src/storefront/pixelate.clj
@@ -68,8 +68,8 @@
         window-height (int (* height led/row-count))]
     { :x-start window-x
       :y-start window-y
-      :x-end (+ 1 (+ window-x window-width))
-      :y-end (+ 1 (+ window-y window-height)) }))
+      :x-end (min (+ 1 (+ window-x window-width)) led/col-count)
+      :y-end (min (+ 1 (+ window-y window-height)) led/row-count) }))
 
 (defn decompose-color [color]
   [(q/red color) (q/green color) (q/blue color)])

--- a/src/storefront/pixelate.clj
+++ b/src/storefront/pixelate.clj
@@ -75,10 +75,10 @@
   [(q/red color) (q/green color) (q/blue color)])
 
 (defn draw-screen [state]
-    (q/no-stroke)
-    (doseq [pixel (:showing-pixels state)]
-      (q/fill (:color pixel))
-      (q/rect (:x pixel) (:y pixel) (:w pixel) (:h pixel))))
+  (q/no-stroke)
+  (doseq [pixel (:showing-pixels state)]
+    (q/fill (:color pixel))
+    (q/rect (:x pixel) (:y pixel) (:w pixel) (:h pixel))))
 
 (defn draw-leds [state]
   (let [options (:options state)

--- a/src/storefront/pixelate.clj
+++ b/src/storefront/pixelate.clj
@@ -36,6 +36,7 @@
     { :pixel-multiplier pixel-multiplier
       :options options
       :hidden-pixels (shuffled-pixels pixel-multiplier)
+      :new-pixels '()
       :showing-pixels '() }))
 
 (defn update-state [state]
@@ -50,6 +51,7 @@
         options    (:options state)]
   { :pixel-multiplier multiplier
     :hidden-pixels hidden
+    :new-pixels new-pixels
     :showing-pixels showing
     :options options}))
 
@@ -72,17 +74,23 @@
 (defn decompose-color [color]
   [(q/red color) (q/green color) (q/blue color)])
 
-(defn draw-state [state]
+(defn draw-screen [state]
+    (q/no-stroke)
+    (doseq [pixel (:showing-pixels state)]
+      (q/fill (:color pixel))
+      (q/rect (:x pixel) (:y pixel) (:w pixel) (:h pixel))))
+
+(defn draw-leds [state]
   (let [options (:options state)
         serial  (:serial options)]
-    (q/no-stroke)
-    (doseq [pixel (:showing-pixels state)
-      :let [window (convert-window pixel)
-            color (:color pixel)]]
-      (q/fill color)
-      (q/rect (:x pixel) (:y pixel) (:w pixel) (:h pixel))
-      (led/paint-window serial (:y-start window) (:x-start window) (:y-end window) (:x-end window) (decompose-color color)))
+    (doseq [pixel (:new-pixels state)
+      :let [window (convert-window pixel)]]
+      (led/paint-window serial (:y-start window) (:x-start window) (:y-end window) (:x-end window) (decompose-color (:color pixel))))
     (led/refresh serial)))
+
+(defn draw-state [state]
+  (draw-screen state)
+  (draw-leds state))
 
 (defn exit? [state]
   (let [mult (:pixel-multiplier state)


### PR DESCRIPTION
## Why?
https://github.com/smashingboxes/storefront/issues/32

## What?
The LED array replicates the pixelation effect.

We may actually want to exaggerate the effect -- since the LED screen is lower resolution, the pixelation isn't as pronounced. But I think it's still kind of cool since the equivalent led position is changed at the same time that the screen position changes.

Also, I don't know anything about the performance characteristics of this on the actual hardware.

Ideas to explore:
* We could 'grow' the LED pixel rectangles over time, proportionally larger than the screen pixels regions, to exaggerate the pixelation on the inherently more 'pixelized' led screen.
* We could fade the LEDs in, so they start with like a 0.1 brightness multiplier and increase the brightness to 1.0 over several seconds

Notes about paint-window:
* It might be nice if the paint-window command took a vector for the window params - so we can compute the window in a function and pass the result straight paint-window
* rectangle functions are usually ordered 'x y width height' - took me a while to figure out why I was getting out-of-index errors until i figured out I had them swapped